### PR TITLE
git: Añadir pre-commit hook + .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.adoc text
+*.js text
+*.html text
+*.yml text
+*.json text
+*.md text

--- a/hooks/README.adoc
+++ b/hooks/README.adoc
@@ -1,0 +1,9 @@
+= Git Hooks
+Git hooks to ease development.
+
+== pre-commit
+This script strips trailing whitespaces from the files on the index.
+Whitespace changes make commit diffs more difficult to read.
+
+To install it, copy the pre-commit script to .git/hooks +
+*Note*: Make sure the script is executable

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# A git hook script to find and fix trailing whitespace
+# in your commits. Bypass it with the --no-verify option
+# to git-commit
+# Ref - http://is.gd/PerowD
+#
+
+if ! git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    exit 0
+fi
+
+files=$(git diff-index --check HEAD -- | sed '/^[+-]/d' | sed 's/:[0-9]*:.*//g' | uniq)
+
+for FILE in $files; do
+	(sed -i 's/[[:space:]]*$//' "$FILE" > /dev/null 2>&1 || sed -i '' -E 's/[[:space:]]*$//' "$FILE")
+	git add "$FILE"
+	echo "NOTE: removed trailing whitespace from $FILE"
+done


### PR DESCRIPTION
Añadir hook de git para eliminar espacios innecesarios al final de las lineas.
También, añadir un archivo .gitattributes para que el fin de linea sea normalizado en los ficheros de texto

Creo que estaría bien que todos utilizásemos esta hook de git. Se "engancha" antes de hacer commit, y corrige espacios en blanco al final de la linea.

El problema de los espacios en blanco, es que suelen molestar, y "ensuciar" los diffs de los commits. 

De cualquier forma, deberíamos configurar todos nuestros editores para que eliminasen los espacios en blanco ("strip whitespace")

Todas las diferencias entre espacios, saltos de linea, etc... deberíamos evitarlas. Al final solo hacen que causar conflictos, y no sirven de nada (ni siquiera las podemos ver)