### PR TITLE
Arreglo de estadísticas en front para mejorar paginación y botones

### DIFF
--- a/webapp/src/__tests__/Statistics.test.js
+++ b/webapp/src/__tests__/Statistics.test.js
@@ -70,7 +70,7 @@ describe('Statistics component', () => {
         // Verificamos que se cargue el contenido principal usando heurísticas de contenido
         await waitFor(() => {
             expect(
-                screen.getByText((text) => text.toLowerCase().includes('picture game'))
+                screen.getByText((text) => text.toLowerCase().includes('pictures game'))
             ).toBeInTheDocument();
         });
     });


### PR DESCRIPTION
Mejorada la página de estadísticas para que se muestren ahora 6 por página y se paginen correctamente
Además el botón no necesita que hayas seleccionado previamente Pictures Game para mostrar las preguntas ya que al tener 1 solo modo de juego no tiene mucho sentido y no es intuitivo
Cambie un nombre de un botón y por eso tuve que arreglar el test